### PR TITLE
install numpy with numba

### DIFF
--- a/switchboard.py
+++ b/switchboard.py
@@ -126,7 +126,8 @@ def conda_create_env(name):
 
 
 def conda_install_numba_dev(env):
-    execute("conda install -y -n {} -c numba/label/dev numba".format(env))
+    execute("conda install -y -n {} -c numba/label/dev numba numpy"
+            .format(env))
 
 
 def conda_install(env, target):


### PR DESCRIPTION
This avoids certain issues with the conda SAT resolver where numba and numpy
versions downgrade each other.