### PR TITLE
pin pytest to 4.x

### DIFF
--- a/switchboard.py
+++ b/switchboard.py
@@ -409,7 +409,7 @@ class FastparquetTests(NumbaIntegrationTestTarget):
 
     @property
     def conda_dependencies(self):
-        return ["numpy pandas pytest "
+        return ["numpy pandas pytest<5.0.0"
                 "brotli thrift python-snappy lz4 s3fs moto cython setuptools ",
                 "-c conda-forge bson zstandard python-lzo",
                 ]


### PR DESCRIPTION
Changes in pytest 5.0.0 are causing breakage in the fastparquet tests,
so we pin to 4.x for the time being.