### PR TITLE
Change clifford to run with pytest

### DIFF
--- a/switchboard.py
+++ b/switchboard.py
@@ -118,6 +118,7 @@ class CliffordTests(GitTarget):
     def conda_dependencies(self):
         return [
             "numpy scipy numba pip h5py pytest",
+            "-c conda-forge sparse",
         ]
 
     @property

--- a/switchboard.py
+++ b/switchboard.py
@@ -117,7 +117,7 @@ class CliffordTests(GitTarget):
     @property
     def conda_dependencies(self):
         return [
-            "future numpy scipy numba pip nose h5py",
+            "numpy scipy numba pip h5py",
         ]
 
     @property
@@ -126,7 +126,7 @@ class CliffordTests(GitTarget):
 
     @property
     def test_command(self):
-        return "nosetests"
+        return "pytest -v clifford/test"
 
 
 class AwkwardTests(GitTarget):

--- a/switchboard.py
+++ b/switchboard.py
@@ -117,7 +117,7 @@ class CliffordTests(GitTarget):
     @property
     def conda_dependencies(self):
         return [
-            "numpy scipy numba pip h5py",
+            "numpy scipy numba pip h5py pytest",
         ]
 
     @property


### PR DESCRIPTION
We've dropped our nose dependency in clifford, and moved away from unittest-compatible tests in order to use pytest fixtures. Since python 2 is also not supported, the `future` module is no longer a dependency.

The upshot is our tests should be more granular.