### PR TITLE
Pin bokeh in datashader integration tests for now

### DIFF
--- a/switchboard.py
+++ b/switchboard.py
@@ -260,7 +260,7 @@ class DatashaderTests(GitTarget):
 
     @property
     def conda_dependencies(self):
-        return ["python<3.8", "pytest>=3.9.3", "fastparquet>=0.1.6", "pytest-benchmark>=3.0.0"]
+        return ["python<3.8", "pytest>=3.9.3", "fastparquet>=0.1.6", "pytest-benchmark>=3.0.0", "bokeh<2.0"]
 
     @property
     def install_command(self):


### PR DESCRIPTION
Current datashader release has some incompatibilities with bokeh>=2.0, so to get tests passing this should work for now.