### PR TITLE
packaging is now a dependency of texasbbq

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,6 +15,7 @@ commands:
     steps:
       - checkout
       - run: sudo pip install --upgrade pip
+      - run: sudo pip install packaging
       - run: sudo pip install git+https://github.com/numba/texasbbq
       - run:
           command: python switchboard.py -t << parameters.target >>


### PR DESCRIPTION
The reason this doesn't show up in the TexasBBQ system tests is bacause
that tests also installs `pytest`  which includes `packaging` as a
dependency.