### PR TITLE
fix version determination for sparse

### DIFF
--- a/switchboard.py
+++ b/switchboard.py
@@ -165,7 +165,7 @@ class SparseTests(GitTarget):
 
     @property
     def git_ref(self):
-        return git_latest_tag(self.clone_url)
+        return git_latest_tag(self.clone_url, vprefix=False)
 
     @property
     def conda_dependencies(self):

--- a/switchboard.py
+++ b/switchboard.py
@@ -6,6 +6,7 @@ from texasbbq import (main,
                       execute,
                       git_clone_ref,
                       git_ls_remote_tags,
+                      git_latest_tag,
                       CondaSource,
                       GitTarget,
                       )
@@ -164,7 +165,7 @@ class SparseTests(GitTarget):
 
     @property
     def git_ref(self):
-        return git_ls_remote_tags(self.clone_url)[-1]
+        return git_latest_tag(self.clone_url)
 
     @property
     def conda_dependencies(self):


### PR DESCRIPTION
Sparse now has a version 0.10.0 -- however the old version sorting code
would not pick this up and determine that 0.9.1 is the latest version.
But, with https://github.com/numba/texasbbq/pull/16 we can use the new,
`packaging` based comparison to determine the correct version.