### PR TITLE
fix numba install command

### DIFF
--- a/switchboard.py
+++ b/switchboard.py
@@ -22,7 +22,7 @@ class NumbaSource(CondaSource):
 
     @property
     def conda_package(self):
-        return "-c numba/label/dev numba"
+        return "--update-specs numba/label/dev::numba"
 
 
 class UmapTests(GitTarget):


### PR DESCRIPTION
The `--update-specs numba/label/dev::numba` will either install the
latest dev release of Numba if Numba is not present, or update Numba to
the latest dev package if this is not yet installed.