### PR TITLE
remove pygbm

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,11 +58,6 @@ jobs:
     steps:
       - run-target:
           target: "fastparquet"
-  pygbm:
-    executor: test-executor
-    steps:
-      - run-target:
-          target: "pygbm"
   datashader:
     executor: test-executor
     steps:
@@ -80,7 +75,6 @@ workflows:
       - awkward
       - sparse
       - fastparquet
-      - pygbm
       - datashader
   nightly-integration-testing:
     jobs:
@@ -90,7 +84,6 @@ workflows:
       - awkward
       - sparse
       - fastparquet
-      - pygbm
       - datashader
     triggers:
       - schedule:

--- a/switchboard.py
+++ b/switchboard.py
@@ -228,33 +228,6 @@ class FastparquetTests(GitTarget):
         os.environ.pop("AWS_SECRET_ACCESS_KEY")
 
 
-class PygbmTests(GitTarget):
-
-    @property
-    def name(self):
-        return "pygbm"
-
-    @property
-    def clone_url(self):
-        return "https://github.com/ogrisel/pygbm.git"
-
-    @property
-    def git_ref(self):
-        return(git_ls_remote_tags(self.clone_url)[-1])
-
-    @property
-    def conda_dependencies(self):
-        return ["scipy scikit-learn pytest joblib lightgbm"]
-
-    @property
-    def install_command(self):
-        return "pip install --editable ."
-
-    @property
-    def test_command(self):
-        return "pytest"
-
-
 class DatashaderTests(GitTarget):
 
     @property


### PR DESCRIPTION
We (the Numba devs) have decided to remove pygbm since recent Numba
versions are no longer compatible with pygbm as outlined in
https://github.com/ogrisel/pygbm/issues/98