### PR TITLE
unpin pandas

### DIFF
--- a/switchboard.py
+++ b/switchboard.py
@@ -203,7 +203,7 @@ class FastparquetTests(GitTarget):
 
     @property
     def conda_dependencies(self):
-        return ["python numpy pandas==1.0.5 moto cython setuptools pytest",
+        return ["python numpy pandas moto cython setuptools pytest",
                 # compression algos available via defaults/main
                 "brotli thrift python-snappy lz4",
                 # compression algos available via conda-forge


### PR DESCRIPTION
Unpinning pandas, due to some recent test failures. Unfortunately, on my Mac this leads to a segfault (below). Opening this to see what CircleCI thinks of this.

```
::>> running: 'conda run --no-capture-output -n fastparquet python setup.py test'
running pytest
Searching for zstd
Reading https://pypi.org/simple/zstd/
Downloading https://files.pythonhosted.org/packages/92/bc/6bc155c61db55d5b3111a8afc76aaec084372bde89a82ecd4f5fd96c639a/zstd-1.4.8.1.tar.gz#sha256=b62b21eb850abd6b8c0046bfc1c5c773c873eeb94f1904ef1ff304e98b62b80e
Best match: zstd 1.4.8.1
Processing zstd-1.4.8.1.tar.gz
Writing /var/folders/jk/s59wn3zx5g92kvk6t9k74fzr0000gn/T/easy_install-91sj_1pw/zstd-1.4.8.1/setup.cfg
Running zstd-1.4.8.1/setup.py -q bdist_egg --dist-dir /var/folders/jk/s59wn3zx5g92kvk6t9k74fzr0000gn/T/easy_install-91sj_1pw/zstd-1.4.8.1/egg-dist-tmp-hyghuwr2
warning: no files found matching 'README.md'
zip_safe flag not set; analyzing archive contents...
__pycache__.zstd.cpython-37: module references __file__
creating /Users/vhaenel/git/numba-integration-testing/fastparquet/.eggs/zstd-1.4.8.1-py3.7-macosx-10.9-x86_64.egg
Extracting zstd-1.4.8.1-py3.7-macosx-10.9-x86_64.egg to /Users/vhaenel/git/numba-integration-testing/fastparquet/.eggs

Installed /Users/vhaenel/git/numba-integration-testing/fastparquet/.eggs/zstd-1.4.8.1-py3.7-macosx-10.9-x86_64.egg
Searching for zstandard
Reading https://pypi.org/simple/zstandard/
Downloading https://files.pythonhosted.org/packages/04/a5/97dd40c1a2c54f6cbb41097ff0869f7c56ac12c5c4f265c982996d5dd207/zstandard-0.15.1-cp37-cp37m-macosx_10_9_x86_64.whl#sha256=8de12b37d32a9128a72b6050d4c6070a3bc944557f6b9912ecfc421f9ee97824
Best match: zstandard 0.15.1
Processing zstandard-0.15.1-cp37-cp37m-macosx_10_9_x86_64.whl
Installing zstandard-0.15.1-cp37-cp37m-macosx_10_9_x86_64.whl to /Users/vhaenel/git/numba-integration-testing/fastparquet/.eggs

Installed /Users/vhaenel/git/numba-integration-testing/fastparquet/.eggs/zstandard-0.15.1-py3.7-macosx-10.9-x86_64.egg
running egg_info
writing fastparquet.egg-info/PKG-INFO
writing dependency_links to fastparquet.egg-info/dependency_links.txt
writing requirements to fastparquet.egg-info/requires.txt
writing top-level names to fastparquet.egg-info/top_level.txt
reading manifest file 'fastparquet.egg-info/SOURCES.txt'
reading manifest template 'MANIFEST.in'
no previously-included directories found matching 'test-data/'
no previously-included directories found matching 'docs/'
writing manifest file 'fastparquet.egg-info/SOURCES.txt'
running build_ext
copying build/lib.macosx-10.9-x86_64-3.7/fastparquet/speedups.cpython-37m-darwin.so -> fastparquet
========================================================================= test session starts =========================================================================
platform darwin -- Python 3.7.9, pytest-6.2.1, py-1.10.0, pluggy-0.13.1 -- /Users/vhaenel/git/numba-integration-testing/miniconda3/envs/fastparquet/bin/python
cachedir: .pytest_cache
rootdir: /Users/vhaenel/git/numba-integration-testing/fastparquet, configfile: setup.cfg
collected 311 items

fastparquet/test/test_api.py::test_import_without_warning PASSED                                                                                                [  0%]
fastparquet/test/test_api.py::test_statistics PASSED                                                                                                            [  0%]
fastparquet/test/test_api.py::test_logical_types PASSED                                                                                                         [  0%]
fastparquet/test/test_api.py::test_empty_statistics PASSED                                                                                                      [  1%]
fastparquet/test/test_api.py::test_sorted_row_group_columns PASSED                                                                                              [  1%]
fastparquet/test/test_api.py::test_sorted_row_group_columns_with_filters SKIPPED (could not import 'dask.dataframe': No module named 'dask')                    [  1%]
fastparquet/test/test_api.py::test_iter PASSED                                                                                                                  [  2%]
fastparquet/test/test_api.py::test_attributes PASSED                                                                                                            [  2%]
fastparquet/test/test_api.py::test_open_standard PASSED                                                                                                         [  2%]
fastparquet/test/test_api.py::test_filelike PASSED                                                                                                              [  3%]
fastparquet/test/test_api.py::test_cast_index PASSED                                                                                                            [  3%]
fastparquet/test/test_api.py::test_zero_child_leaf PASSED                                                                                                       [  3%]
fastparquet/test/test_api.py::test_request_nonexistent_column PASSED                                                                                            [  4%]
fastparquet/test/test_api.py::test_read_multiple_no_metadata PASSED                                                                                             [  4%]
fastparquet/test/test_api.py::test_single_upper_directory PASSED                                                                                                [  4%]
fastparquet/test/test_api.py::test_numerical_partition_name PASSED                                                                                              [  5%]
fastparquet/test/test_api.py::test_floating_point_partition_name PASSED                                                                                         [  5%]
fastparquet/test/test_api.py::test_datetime_partition_names PASSED                                                                                              [  5%]
fastparquet/test/test_api.py::test_string_partition_names PASSED                                                                                                [  6%]
fastparquet/test/test_api.py::test_mixed_partition_types[partitions0] PASSED                                                                                    [  6%]
fastparquet/test/test_api.py::test_mixed_partition_types[partitions1] PASSED                                                                                    [  6%]
fastparquet/test/test_api.py::test_filter_without_paths PASSED                                                                                                  [  7%]
fastparquet/test/test_api.py::test_filter_special PASSED                                                                                                        [  7%]
fastparquet/test/test_api.py::test_filter_dates PASSED                                                                                                          [  7%]
fastparquet/test/test_api.py::test_in_filter PASSED                                                                                                             [  8%]
fastparquet/test/test_api.py::test_in_filter_numbers PASSED                                                                                                     [  8%]
fastparquet/test/test_api.py::test_filter_stats PASSED                                                                                                          [  8%]
fastparquet/test/test_api.py::test_in_filters[vals0-None-None-False-False] PASSED                                                                               [  9%]
fastparquet/test/test_api.py::test_in_filters[vals1-3-3-False-True] PASSED                                                                                      [  9%]
fastparquet/test/test_api.py::test_in_filters[vals2-2-2-True-False] PASSED                                                                                      [  9%]
fastparquet/test/test_api.py::test_in_filters[vals3-None-7-False-False] PASSED                                                                                  [  9%]
fastparquet/test/test_api.py::test_in_filters[vals4-None-2-True-False] PASSED                                                                                   [ 10%]
fastparquet/test/test_api.py::test_in_filters[vals5-2-None-False-False] PASSED                                                                                  [ 10%]
fastparquet/test/test_api.py::test_in_filters[vals6-7-None-True-False] PASSED                                                                                   [ 10%]
fastparquet/test/test_api.py::test_in_filters[vals7-2-4-False-False] PASSED                                                                                     [ 11%]
fastparquet/test/test_api.py::test_in_filters[vals8-5-6-False-True] PASSED                                                                                      [ 11%]
fastparquet/test/test_api.py::test_in_filters[vals9-2-3-False-True] PASSED                                                                                      [ 11%]
fastparquet/test/test_api.py::test_in_filters[vals10-6-7-False-True] PASSED                                                                                     [ 12%]
fastparquet/test/test_api.py::test_in_filters[vals11-1-2-True-False] PASSED                                                                                     [ 12%]
fastparquet/test/test_api.py::test_in_filters[vals12-7-8-True-False] PASSED                                                                                     [ 12%]
fastparquet/test/test_api.py::test_in_filters[vals13-1-8-False-False] PASSED                                                                                    [ 13%]
fastparquet/test/test_api.py::test_in_filters[vals14-1-8-True-False] PASSED                                                                                     [ 13%]
fastparquet/test/test_api.py::test_in_filter_rowgroups PASSED                                                                                                   [ 13%]
fastparquet/test/test_api.py::test_index_not_in_columns PASSED                                                                                                  [ 14%]
fastparquet/test/test_api.py::test_no_index_name PASSED                                                                                                         [ 14%]
fastparquet/test/test_api.py::test_input_column_list_not_mutated PASSED                                                                                         [ 14%]
fastparquet/test/test_api.py::test_drill_list PASSED                                                                                                            [ 15%]
fastparquet/test/test_api.py::test_multi_list PASSED                                                                                                            [ 15%]
fastparquet/test/test_api.py::test_hive_and_drill_list PASSED                                                                                                   [ 15%]
fastparquet/test/test_api.py::test_bad_file_paths PASSED                                                                                                        [ 16%]
fastparquet/test/test_api.py::test_compression_zstandard PASSED                                                                                                 [ 16%]
fastparquet/test/test_api.py::test_compression_zstd PASSED                                                                                                      [ 16%]
fastparquet/test/test_api.py::test_compression_lz4 PASSED                                                                                                       [ 17%]
fastparquet/test/test_api.py::test_compression_snappy PASSED                                                                                                    [ 17%]
fastparquet/test/test_api.py::test_int96_stats PASSED                                                                                                           [ 17%]
fastparquet/test/test_api.py::test_only_partition_columns PASSED                                                                                                [ 18%]
fastparquet/test/test_api.py::test_path_containing_metadata_df PASSED                                                                                           [ 18%]
fastparquet/test/test_api.py::test_empty_df PASSED                                                                                                              [ 18%]
fastparquet/test/test_api.py::test_unicode_cols PASSED                                                                                                          [ 18%]
fastparquet/test/test_api.py::test_multi_cat PASSED                                                                                                             [ 19%]
fastparquet/test/test_api.py::test_multi_cat_single PASSED                                                                                                      [ 19%]
fastparquet/test/test_api.py::test_multi_cat_fail PASSED                                                                                                        [ 19%]
fastparquet/test/test_api.py::test_multi PASSED                                                                                                                 [ 20%]
fastparquet/test/test_api.py::test_simple_nested PASSED                                                                                                         [ 20%]
fastparquet/test/test_api.py::test_pandas_metadata_inference PASSED                                                                                             [ 20%]
fastparquet/test/test_aroundtrips.py::test_map_array SKIPPED (could not import 'pyspark': No module named 'pyspark')                                            [ 21%]
fastparquet/test/test_aroundtrips.py::test_nested_list SKIPPED (could not import 'pyspark': No module named 'pyspark')                                          [ 21%]
fastparquet/test/test_aroundtrips.py::test_pyspark_roundtrip[None-row_groups0-simple] SKIPPED (could not import 'pyspark': No module named 'pyspark')           [ 21%]
fastparquet/test/test_aroundtrips.py::test_pyspark_roundtrip[None-row_groups0-hive] SKIPPED (could not import 'pyspark': No module named 'pyspark')             [ 22%]
fastparquet/test/test_aroundtrips.py::test_pyspark_roundtrip[None-row_groups0-drill] SKIPPED (could not import 'pyspark': No module named 'pyspark')            [ 22%]
fastparquet/test/test_aroundtrips.py::test_pyspark_roundtrip[None-row_groups1-simple] SKIPPED (could not import 'pyspark': No module named 'pyspark')           [ 22%]
fastparquet/test/test_aroundtrips.py::test_pyspark_roundtrip[None-row_groups1-hive] SKIPPED (could not import 'pyspark': No module named 'pyspark')             [ 23%]
fastparquet/test/test_aroundtrips.py::test_pyspark_roundtrip[None-row_groups1-drill] SKIPPED (could not import 'pyspark': No module named 'pyspark')            [ 23%]
fastparquet/test/test_aroundtrips.py::test_pyspark_roundtrip[UNCOMPRESSED-row_groups0-simple] SKIPPED (could not import 'pyspark': No module named 'pyspark')   [ 23%]
fastparquet/test/test_aroundtrips.py::test_pyspark_roundtrip[UNCOMPRESSED-row_groups0-hive] SKIPPED (could not import 'pyspark': No module named 'pyspark')     [ 24%]
fastparquet/test/test_aroundtrips.py::test_pyspark_roundtrip[UNCOMPRESSED-row_groups0-drill] SKIPPED (could not import 'pyspark': No module named 'pyspark')    [ 24%]
fastparquet/test/test_aroundtrips.py::test_pyspark_roundtrip[UNCOMPRESSED-row_groups1-simple] SKIPPED (could not import 'pyspark': No module named 'pyspark')   [ 24%]
fastparquet/test/test_aroundtrips.py::test_pyspark_roundtrip[UNCOMPRESSED-row_groups1-hive] SKIPPED (could not import 'pyspark': No module named 'pyspark')     [ 25%]
fastparquet/test/test_aroundtrips.py::test_pyspark_roundtrip[UNCOMPRESSED-row_groups1-drill] SKIPPED (could not import 'pyspark': No module named 'pyspark')    [ 25%]
fastparquet/test/test_aroundtrips.py::test_pyspark_roundtrip[GZIP-row_groups0-simple] SKIPPED (could not import 'pyspark': No module named 'pyspark')           [ 25%]
fastparquet/test/test_aroundtrips.py::test_pyspark_roundtrip[GZIP-row_groups0-hive] SKIPPED (could not import 'pyspark': No module named 'pyspark')             [ 26%]
fastparquet/test/test_aroundtrips.py::test_pyspark_roundtrip[GZIP-row_groups0-drill] SKIPPED (could not import 'pyspark': No module named 'pyspark')            [ 26%]
fastparquet/test/test_aroundtrips.py::test_pyspark_roundtrip[GZIP-row_groups1-simple] SKIPPED (could not import 'pyspark': No module named 'pyspark')           [ 26%]
fastparquet/test/test_aroundtrips.py::test_pyspark_roundtrip[GZIP-row_groups1-hive] SKIPPED (could not import 'pyspark': No module named 'pyspark')             [ 27%]
fastparquet/test/test_aroundtrips.py::test_pyspark_roundtrip[GZIP-row_groups1-drill] SKIPPED (could not import 'pyspark': No module named 'pyspark')            [ 27%]
fastparquet/test/test_aroundtrips.py::test_pyspark_roundtrip[SNAPPY-row_groups0-simple] SKIPPED (could not import 'pyspark': No module named 'pyspark')         [ 27%]
fastparquet/test/test_aroundtrips.py::test_pyspark_roundtrip[SNAPPY-row_groups0-hive] SKIPPED (could not import 'pyspark': No module named 'pyspark')           [ 27%]
fastparquet/test/test_aroundtrips.py::test_pyspark_roundtrip[SNAPPY-row_groups0-drill] SKIPPED (could not import 'pyspark': No module named 'pyspark')          [ 28%]
fastparquet/test/test_aroundtrips.py::test_pyspark_roundtrip[SNAPPY-row_groups1-simple] SKIPPED (could not import 'pyspark': No module named 'pyspark')         [ 28%]
fastparquet/test/test_aroundtrips.py::test_pyspark_roundtrip[SNAPPY-row_groups1-hive] SKIPPED (could not import 'pyspark': No module named 'pyspark')           [ 28%]
fastparquet/test/test_aroundtrips.py::test_pyspark_roundtrip[SNAPPY-row_groups1-drill] SKIPPED (could not import 'pyspark': No module named 'pyspark')          [ 29%]
fastparquet/test/test_aroundtrips.py::test_pyspark_roundtrip[LZO-row_groups0-simple] SKIPPED (could not import 'pyspark': No module named 'pyspark')            [ 29%]
fastparquet/test/test_aroundtrips.py::test_pyspark_roundtrip[LZO-row_groups0-hive] SKIPPED (could not import 'pyspark': No module named 'pyspark')              [ 29%]
fastparquet/test/test_aroundtrips.py::test_pyspark_roundtrip[LZO-row_groups0-drill] SKIPPED (could not import 'pyspark': No module named 'pyspark')             [ 30%]
fastparquet/test/test_aroundtrips.py::test_pyspark_roundtrip[LZO-row_groups1-simple] SKIPPED (could not import 'pyspark': No module named 'pyspark')            [ 30%]
fastparquet/test/test_aroundtrips.py::test_pyspark_roundtrip[LZO-row_groups1-hive] SKIPPED (could not import 'pyspark': No module named 'pyspark')              [ 30%]
fastparquet/test/test_aroundtrips.py::test_pyspark_roundtrip[LZO-row_groups1-drill] SKIPPED (could not import 'pyspark': No module named 'pyspark')             [ 31%]
fastparquet/test/test_aroundtrips.py::test_pyspark_roundtrip[BROTLI-row_groups0-simple] SKIPPED (could not import 'pyspark': No module named 'pyspark')         [ 31%]
fastparquet/test/test_aroundtrips.py::test_pyspark_roundtrip[BROTLI-row_groups0-hive] SKIPPED (could not import 'pyspark': No module named 'pyspark')           [ 31%]
fastparquet/test/test_aroundtrips.py::test_pyspark_roundtrip[BROTLI-row_groups0-drill] SKIPPED (could not import 'pyspark': No module named 'pyspark')          [ 32%]
fastparquet/test/test_aroundtrips.py::test_pyspark_roundtrip[BROTLI-row_groups1-simple] SKIPPED (could not import 'pyspark': No module named 'pyspark')         [ 32%]
fastparquet/test/test_aroundtrips.py::test_pyspark_roundtrip[BROTLI-row_groups1-hive] SKIPPED (could not import 'pyspark': No module named 'pyspark')           [ 32%]
fastparquet/test/test_aroundtrips.py::test_pyspark_roundtrip[BROTLI-row_groups1-drill] SKIPPED (could not import 'pyspark': No module named 'pyspark')          [ 33%]
fastparquet/test/test_aroundtrips.py::test_pyspark_roundtrip[LZ4-row_groups0-simple] SKIPPED (could not import 'pyspark': No module named 'pyspark')            [ 33%]
fastparquet/test/test_aroundtrips.py::test_pyspark_roundtrip[LZ4-row_groups0-hive] SKIPPED (could not import 'pyspark': No module named 'pyspark')              [ 33%]
fastparquet/test/test_aroundtrips.py::test_pyspark_roundtrip[LZ4-row_groups0-drill] SKIPPED (could not import 'pyspark': No module named 'pyspark')             [ 34%]
fastparquet/test/test_aroundtrips.py::test_pyspark_roundtrip[LZ4-row_groups1-simple] SKIPPED (could not import 'pyspark': No module named 'pyspark')            [ 34%]
fastparquet/test/test_aroundtrips.py::test_pyspark_roundtrip[LZ4-row_groups1-hive] SKIPPED (could not import 'pyspark': No module named 'pyspark')              [ 34%]
fastparquet/test/test_aroundtrips.py::test_pyspark_roundtrip[LZ4-row_groups1-drill] SKIPPED (could not import 'pyspark': No module named 'pyspark')             [ 35%]
fastparquet/test/test_aroundtrips.py::test_pyspark_roundtrip[ZSTD-row_groups0-simple] SKIPPED (could not import 'pyspark': No module named 'pyspark')           [ 35%]
fastparquet/test/test_aroundtrips.py::test_pyspark_roundtrip[ZSTD-row_groups0-hive] SKIPPED (could not import 'pyspark': No module named 'pyspark')             [ 35%]
fastparquet/test/test_aroundtrips.py::test_pyspark_roundtrip[ZSTD-row_groups0-drill] SKIPPED (could not import 'pyspark': No module named 'pyspark')            [ 36%]
fastparquet/test/test_aroundtrips.py::test_pyspark_roundtrip[ZSTD-row_groups1-simple] SKIPPED (could not import 'pyspark': No module named 'pyspark')           [ 36%]
fastparquet/test/test_aroundtrips.py::test_pyspark_roundtrip[ZSTD-row_groups1-hive] SKIPPED (could not import 'pyspark': No module named 'pyspark')             [ 36%]
fastparquet/test/test_aroundtrips.py::test_pyspark_roundtrip[ZSTD-row_groups1-drill] SKIPPED (could not import 'pyspark': No module named 'pyspark')            [ 36%]
fastparquet/test/test_aroundtrips.py::test_empty_row_groups SKIPPED (could not import 'pyspark': No module named 'pyspark')                                     [ 37%]
fastparquet/test/test_compression.py::test_compress_decompress_roundtrip[UNCOMPRESSED] PASSED                                                                   [ 37%]
fastparquet/test/test_compression.py::test_compress_decompress_roundtrip[GZIP] PASSED                                                                           [ 37%]
fastparquet/test/test_compression.py::test_compress_decompress_roundtrip[SNAPPY] PASSED                                                                         [ 38%]
fastparquet/test/test_compression.py::test_compress_decompress_roundtrip[LZO] PASSED                                                                            [ 38%]
fastparquet/test/test_compression.py::test_compress_decompress_roundtrip[BROTLI] PASSED                                                                         [ 38%]
fastparquet/test/test_compression.py::test_compress_decompress_roundtrip[LZ4] PASSED                                                                            [ 39%]
fastparquet/test/test_compression.py::test_compress_decompress_roundtrip[ZSTD] PASSED                                                                           [ 39%]
fastparquet/test/test_compression.py::test_compress_decompress_roundtrip_args_gzip PASSED                                                                       [ 39%]
fastparquet/test/test_compression.py::test_compress_decompress_roundtrip_args_lz4 PASSED                                                                        [ 40%]
fastparquet/test/test_compression.py::test_compress_decompress_roundtrip_args_zstandard PASSED                                                                  [ 40%]
fastparquet/test/test_compression.py::test_compress_decompress_roundtrip_args_zstd PASSED                                                                       [ 40%]
fastparquet/test/test_compression.py::test_errors PASSED                                                                                                        [ 41%]
fastparquet/test/test_compression.py::test_not_installed PASSED                                                                                                 [ 41%]
fastparquet/test/test_converted_types.py::test_int32 PASSED                                                                                                     [ 41%]
fastparquet/test/test_converted_types.py::test_date PASSED                                                                                                      [ 42%]
fastparquet/test/test_converted_types.py::test_time_millis PASSED                                                                                               [ 42%]
fastparquet/test/test_converted_types.py::test_timestamp_millis PASSED                                                                                          [ 42%]
fastparquet/test/test_converted_types.py::test_utf8 PASSED                                                                                                      [ 43%]
fastparquet/test/test_converted_types.py::test_json PASSED                                                                                                      [ 43%]
fastparquet/test/test_converted_types.py::test_bson PASSED                                                                                                      [ 43%]
fastparquet/test/test_converted_types.py::test_uint16 PASSED                                                                                                    [ 44%]
fastparquet/test/test_converted_types.py::test_uint32 PASSED                                                                                                    [ 44%]
fastparquet/test/test_converted_types.py::test_uint64 PASSED                                                                                                    [ 44%]
fastparquet/test/test_converted_types.py::test_big_decimal PASSED                                                                                               [ 45%]
fastparquet/test/test_dataframe.py::test_empty PASSED                                                                                                           [ 45%]
fastparquet/test/test_dataframe.py::test_empty_tz_utc PASSED                                                                                                    [ 45%]
fastparquet/test/test_dataframe.py::test_empty_tz_nonutc PASSED                                                                                                 [ 45%]
fastparquet/test/test_dataframe.py::test_timestamps PASSED                                                                                                      [ 46%]
fastparquet/test/test_dataframe.py::test_pandas_hive_serialization PASSED                                                                                       [ 46%]
fastparquet/test/test_encoding.py::test_int32 PASSED                                                                                                            [ 46%]
fastparquet/test/test_encoding.py::test_int64 PASSED                                                                                                            [ 47%]
fastparquet/test/test_encoding.py::test_int96 PASSED                                                                                                            [ 47%]
fastparquet/test/test_encoding.py::test_float PASSED                                                                                                            [ 47%]
fastparquet/test/test_encoding.py::test_double PASSED                                                                                                           [ 48%]
fastparquet/test/test_encoding.py::test_fixed PASSED                                                                                                            [ 48%]
fastparquet/test/test_encoding.py::test_boolean PASSED                                                                                                          [ 48%]
fastparquet/test/test_encoding.py::testFourByteValue PASSED                                                                                                     [ 49%]
fastparquet/test/test_encoding.py::testSingleByte PASSED                                                                                                        [ 49%]
fastparquet/test/test_encoding.py::testFourByte PASSED                                                                                                          [ 49%]
fastparquet/test/test_encoding.py::testFromExample PASSED                                                                                                       [ 50%]
fastparquet/test/test_encoding.py::testWidths PASSED                                                                                                            [ 50%]
fastparquet/test/test_output.py::test_uvarint PASSED                                                                                                            [ 50%]
fastparquet/test/test_output.py::test_bitpack PASSED                                                                                                            [ 51%]
fastparquet/test/test_output.py::test_length PASSED                                                                                                             [ 51%]
fastparquet/test/test_output.py::test_rle_bp PASSED                                                                                                             [ 51%]
fastparquet/test/test_output.py::test_roundtrip_s3 PASSED                                                                                                       [ 52%]
fastparquet/test/test_output.py::test_roundtrip[None-row_groups0-simple] PASSED                                                                                 [ 52%]
fastparquet/test/test_output.py::test_roundtrip[None-row_groups0-hive] PASSED                                                                                   [ 52%]
fastparquet/test/test_output.py::test_roundtrip[None-row_groups1-simple] PASSED                                                                                 [ 53%]
fastparquet/test/test_output.py::test_roundtrip[None-row_groups1-hive] PASSED                                                                                   [ 53%]
fastparquet/test/test_output.py::test_roundtrip[GZIP-row_groups0-simple] PASSED                                                                                 [ 53%]
fastparquet/test/test_output.py::test_roundtrip[GZIP-row_groups0-hive] PASSED                                                                                   [ 54%]
fastparquet/test/test_output.py::test_roundtrip[GZIP-row_groups1-simple] PASSED                                                                                 [ 54%]
fastparquet/test/test_output.py::test_roundtrip[GZIP-row_groups1-hive] PASSED                                                                                   [ 54%]
fastparquet/test/test_output.py::test_roundtrip[SNAPPY-row_groups0-simple] PASSED                                                                               [ 54%]
fastparquet/test/test_output.py::test_roundtrip[SNAPPY-row_groups0-hive] PASSED                                                                                 [ 55%]
fastparquet/test/test_output.py::test_roundtrip[SNAPPY-row_groups1-simple] PASSED                                                                               [ 55%]
fastparquet/test/test_output.py::test_roundtrip[SNAPPY-row_groups1-hive] PASSED                                                                                 [ 55%]
fastparquet/test/test_output.py::test_bad_coltype PASSED                                                                                                        [ 56%]
fastparquet/test/test_output.py::test_bad_col PASSED                                                                                                            [ 56%]
fastparquet/test/test_output.py::test_roundtrip_complex[simple] PASSED                                                                                          [ 56%]
fastparquet/test/test_output.py::test_roundtrip_complex[hive] PASSED                                                                                            [ 57%]
fastparquet/test/test_output.py::test_datetime_roundtrip[df0] PASSED                                                                                            [ 57%]
fastparquet/test/test_output.py::test_datetime_roundtrip[df1] PASSED                                                                                            [ 57%]
fastparquet/test/test_output.py::test_datetime_roundtrip[df2] PASSED                                                                                            [ 58%]
fastparquet/test/test_output.py::test_datetime_roundtrip[df3] PASSED                                                                                            [ 58%]
fastparquet/test/test_output.py::test_nulls_roundtrip PASSED                                                                                                    [ 58%]
fastparquet/test/test_output.py::test_decimal_roundtrip PASSED                                                                                                  [ 59%]
fastparquet/test/test_output.py::test_make_definitions_with_nulls PASSED                                                                                        [ 59%]
fastparquet/test/test_output.py::test_make_definitions_without_nulls PASSED                                                                                     [ 59%]
fastparquet/test/test_output.py::test_empty_row_group PASSED                                                                                                    [ 60%]
fastparquet/test/test_output.py::test_write_delta SKIPPED (unconditional skip)                                                                                  [ 60%]
fastparquet/test/test_output.py::test_int_rowgroups PASSED                                                                                                      [ 60%]
fastparquet/test/test_output.py::test_groups_roundtrip[hive] PASSED                                                                                             [ 61%]
fastparquet/test/test_output.py::test_groups_roundtrip[drill] PASSED                                                                                            [ 61%]
fastparquet/test/test_output.py::test_groups_iterable PASSED                                                                                                    [ 61%]
fastparquet/test/test_output.py::test_empty_groupby PASSED                                                                                                      [ 62%]
fastparquet/test/test_output.py::test_too_many_partition_columns PASSED                                                                                         [ 62%]
fastparquet/test/test_output.py::test_read_partitioned_and_write_with_empty_partions PASSED                                                                     [ 62%]
fastparquet/test/test_output.py::test_write_compression_dict[GZIP] PASSED                                                                                       [ 63%]
fastparquet/test/test_output.py::test_write_compression_dict[gzip] PASSED                                                                                       [ 63%]
fastparquet/test/test_output.py::test_write_compression_dict[None] PASSED                                                                                       [ 63%]
fastparquet/test/test_output.py::test_write_compression_dict[compression3] PASSED                                                                               [ 63%]
fastparquet/test/test_output.py::test_write_compression_dict[compression4] PASSED                                                                               [ 64%]
fastparquet/test/test_output.py::test_write_compression_schema PASSED                                                                                           [ 64%]
fastparquet/test/test_output.py::test_index PASSED                                                                                                              [ 64%]
fastparquet/test/test_output.py::test_duplicate_columns PASSED                                                                                                  [ 65%]
fastparquet/test/test_output.py::test_cmd_bytesize[None] PASSED                                                                                                 [ 65%]
fastparquet/test/test_output.py::test_cmd_bytesize[gzip] PASSED                                                                                                 [ 65%]
fastparquet/test/test_output.py::test_dotted_column PASSED                                                                                                      [ 66%]
fastparquet/test/test_output.py::test_naive_index PASSED                                                                                                        [ 66%]
fastparquet/test/test_output.py::test_text_convert PASSED                                                                                                       [ 66%]
fastparquet/test/test_output.py::test_null_time PASSED                                                                                                          [ 67%]
fastparquet/test/test_output.py::test_auto_null PASSED                                                                                                          [ 67%]
fastparquet/test/test_output.py::test_many_categories[10] PASSED                                                                                                [ 67%]
fastparquet/test/test_output.py::test_many_categories[127] PASSED                                                                                               [ 68%]
fastparquet/test/test_output.py::test_many_categories[257] PASSED                                                                                               [ 68%]
fastparquet/test/test_output.py::test_many_categories[65537] PASSED                                                                                             [ 68%]
fastparquet/test/test_output.py::test_write_partitioned_with_empty_categories PASSED                                                                            [ 69%]
fastparquet/test/test_output.py::test_autocat PASSED                                                                                                            [ 69%]
fastparquet/test/test_output.py::test_merge[dirs0-row_groups0] PASSED                                                                                           [ 69%]
fastparquet/test/test_output.py::test_merge[dirs0-row_groups1] PASSED                                                                                           [ 70%]
fastparquet/test/test_output.py::test_merge[dirs1-row_groups0] PASSED                                                                                           [ 70%]
fastparquet/test/test_output.py::test_merge[dirs1-row_groups1] PASSED                                                                                           [ 70%]
fastparquet/test/test_output.py::test_merge_s3 PASSED                                                                                                           [ 71%]
fastparquet/test/test_output.py::test_merge_fail PASSED                                                                                                         [ 71%]
fastparquet/test/test_output.py::test_append_simple PASSED                                                                                                      [ 71%]
fastparquet/test/test_output.py::test_append_empty[hive] PASSED                                                                                                 [ 72%]
fastparquet/test/test_output.py::test_append_empty[simple] PASSED                                                                                               [ 72%]
fastparquet/test/test_output.py::test_append[partition0-row_groups0] PASSED                                                                                     [ 72%]
fastparquet/test/test_output.py::test_append[partition0-row_groups1] PASSED                                                                                     [ 72%]
fastparquet/test/test_output.py::test_append[partition1-row_groups0] PASSED                                                                                     [ 73%]
fastparquet/test/test_output.py::test_append[partition1-row_groups1] PASSED                                                                                     [ 73%]
fastparquet/test/test_output.py::test_append_fail PASSED                                                                                                        [ 73%]
fastparquet/test/test_output.py::test_append_w_partitioning PASSED                                                                                              [ 74%]
fastparquet/test/test_output.py::test_empty_dataframe PASSED                                                                                                    [ 74%]
fastparquet/test/test_output.py::test_hasnulls_ordering PASSED                                                                                                  [ 74%]
fastparquet/test/test_output.py::test_cats_in_part_files PASSED                                                                                                 [ 75%]
fastparquet/test/test_output.py::test_cats_and_nulls PASSED                                                                                                     [ 75%]
fastparquet/test/test_output.py::test_consolidate_cats PASSED                                                                                                   [ 75%]
fastparquet/test/test_output.py::test_bad_object_encoding PASSED                                                                                                [ 76%]
fastparquet/test/test_output.py::test_object_encoding_int32 PASSED                                                                                              [ 76%]
fastparquet/test/test_partition_filters_specialstrings.py::test_frame_write_read_verify[input_symbols0-504-hive-2-partitions0-filters0] PASSED                  [ 76%]
fastparquet/test/test_partition_filters_specialstrings.py::test_frame_write_read_verify[input_symbols1-504-hive-2-partitions1-filters1] PASSED                  [ 77%]
fastparquet/test/test_partition_filters_specialstrings.py::test_frame_write_read_verify[input_symbols2-504-hive-2-partitions2-filters2] PASSED                  [ 77%]
fastparquet/test/test_partition_filters_specialstrings.py::test_frame_write_read_verify[input_symbols3-504-hive-2-partitions3-filters3] PASSED                  [ 77%]
fastparquet/test/test_partition_filters_specialstrings.py::test_frame_write_read_verify[input_symbols4-504-hive-2-partitions4-filters4] PASSED                  [ 78%]
fastparquet/test/test_partition_filters_specialstrings.py::test_frame_write_read_verify[input_symbols5-504-hive-2-partitions5-filters5] PASSED                  [ 78%]
fastparquet/test/test_partition_filters_specialstrings.py::test_frame_write_read_verify[input_symbols6-504-hive-2-partitions6-filters6] PASSED                  [ 78%]
fastparquet/test/test_partition_filters_specialstrings.py::test_frame_write_read_verify[input_symbols7-10-hive-2-partitions7-filters7] PASSED                   [ 79%]
fastparquet/test/test_partition_filters_specialstrings.py::test_frame_write_read_verify[input_symbols8-10-hive-2-partitions8-filters8] PASSED                   [ 79%]
fastparquet/test/test_partition_filters_specialstrings.py::test_frame_write_read_verify[input_symbols9-10-hive-2-partitions9-filters9] PASSED                   [ 79%]
fastparquet/test/test_pd_optional_types.py::test_write_nullable_columns[simple-None] PASSED                                                                     [ 80%]
fastparquet/test/test_pd_optional_types.py::test_write_nullable_columns[simple-snappy] PASSED                                                                   [ 80%]
fastparquet/test/test_pd_optional_types.py::test_write_nullable_columns[simple-gzip] PASSED                                                                     [ 80%]
fastparquet/test/test_pd_optional_types.py::test_write_nullable_columns[hive-None] PASSED                                                                       [ 81%]
fastparquet/test/test_pd_optional_types.py::test_write_nullable_columns[hive-snappy] PASSED                                                                     [ 81%]
fastparquet/test/test_pd_optional_types.py::test_write_nullable_columns[hive-gzip] PASSED                                                                       [ 81%]
fastparquet/test/test_read.py::test_header_magic_bytes PASSED                                                                                                   [ 81%]
fastparquet/test/test_read.py::test_read_footer_fail[1] PASSED                                                                                                  [ 82%]
fastparquet/test/test_read.py::test_read_footer_fail[4] PASSED                                                                                                  [ 82%]
fastparquet/test/test_read.py::test_read_footer_fail[12] PASSED                                                                                                 [ 82%]
fastparquet/test/test_read.py::test_read_footer_fail[20] PASSED                                                                                                 [ 83%]
fastparquet/test/test_read.py::test_read_footer PASSED                                                                                                          [ 83%]
fastparquet/test/test_read.py::test_read_s3 PASSED                                                                                                              [ 83%]
fastparquet/test/test_read.py::test_file_csv[test-data/gzip-nation.impala.parquet] PASSED                                                                       [ 84%]
fastparquet/test/test_read.py::test_file_csv[test-data/nation.dict.parquet] PASSED                                                                              [ 84%]
fastparquet/test/test_read.py::test_file_csv[test-data/nation.impala.parquet] PASSED                                                                            [ 84%]
fastparquet/test/test_read.py::test_file_csv[test-data/nation.plain.parquet] PASSED                                                                             [ 85%]
fastparquet/test/test_read.py::test_file_csv[test-data/snappy-nation.impala.parquet] PASSED                                                                     [ 85%]
fastparquet/test/test_read.py::test_null_int PASSED                                                                                                             [ 85%]
fastparquet/test/test_read.py::test_converted_type_null PASSED                                                                                                  [ 86%]
fastparquet/test/test_read.py::test_null_plain_dictionary PASSED                                                                                                [ 86%]
fastparquet/test/test_read.py::test_dir_partition PASSED                                                                                                        [ 86%]
fastparquet/test/test_read.py::test_stat_filters PASSED                                                                                                         [ 87%]
fastparquet/test/test_read.py::test_cat_filters PASSED                                                                                                          [ 87%]
fastparquet/test/test_read.py::test_statistics PASSED                                                                                                           [ 87%]
fastparquet/test/test_read.py::test_grab_cats PASSED                                                                                                            [ 88%]
fastparquet/test/test_read.py::test_index PASSED                                                                                                                [ 88%]
fastparquet/test/test_read.py::test_skip_length PASSED                                                                                                          [ 88%]
fastparquet/test/test_read.py::test_timestamp96 PASSED                                                                                                          [ 89%]
fastparquet/test/test_read.py::test_bad_catsize PASSED                                                                                                          [ 89%]
fastparquet/test/test_read.py::test_null_sizes PASSED                                                                                                           [ 89%]
fastparquet/test/test_read.py::test_multi_index PASSED                                                                                                          [ 90%]
fastparquet/test/test_read.py::test_multi_index_category PASSED                                                                                                 [ 90%]
fastparquet/test/test_read.py::test_no_columns PASSED                                                                                                           [ 90%]
fastparquet/test/test_read.py::test_map_multipage PASSED                                                                                                        [ 90%]
fastparquet/test/test_read.py::test_map_last_row_split PASSED                                                                                                   [ 91%]
fastparquet/test/test_read.py::test_truncated_decimal PASSED                                                                                                    [ 91%]
fastparquet/test/test_schema.py::test_schema_eq PASSED                                                                                                          [ 91%]
fastparquet/test/test_schema.py::test_schema_ne_subset PASSED                                                                                                   [ 92%]
fastparquet/test/test_schema.py::test_schema_ne_renamed PASSED                                                                                                  [ 92%]
fastparquet/test/test_schema.py::test_schema_ne_converted PASSED                                                                                                [ 92%]
fastparquet/test/test_schema.py::test_schema_ne_different_order PASSED                                                                                          [ 93%]
fastparquet/test/test_speedups.py::test_array_encode_utf8 PASSED                                                                                                [ 93%]
fastparquet/test/test_speedups.py::test_array_decode_utf8 PASSED                                                                                                [ 93%]
fastparquet/test/test_speedups.py::test_pack_byte_array PASSED                                                                                                  [ 94%]
fastparquet/test/test_speedups.py::test_unpack_byte_array PASSED                                                                                                [ 94%]
fastparquet/test/test_thrift_structures.py::test_serialize PASSED                                                                                               [ 94%]
fastparquet/test/test_thrift_structures.py::test_copy PASSED                                                                                                    [ 95%]
fastparquet/test/test_util.py::test_analyse_paths PASSED                                                                                                        [ 95%]
fastparquet/test/test_util.py::test_empty PASSED                                                                                                                [ 95%]
fastparquet/test/test_util.py::test_parents PASSED                                                                                                              [ 96%]
fastparquet/test/test_util.py::test_abs_and_rel_paths PASSED                                                                                                    [ 96%]
fastparquet/test/test_util.py::test_file_scheme PASSED                                                                                                          [ 96%]
fastparquet/test/test_util.py::test_val_to_num PASSED                                                                                                           [ 97%]
fastparquet/test/test_util.py::test_groupby_types PASSED                                                                                                        [ 97%]
fastparquet/test/test_util.py::test_bad_tz PASSED                                                                                                               [ 97%]
fastparquet/test/test_with_n.py::test_read_bitpacked PASSED                                                                                                     [ 98%]
fastparquet/test/test_with_n.py::test_rle PASSED                                                                                                                [ 98%]
fastparquet/test/test_with_n.py::test_uvarint PASSED                                                                                                            [ 98%]
fastparquet/test/test_with_n.py::test_hybrid PASSED                                                                                                             [ 99%]
fastparquet/test/test_with_n.py::test_hybrid_extra_bytes Fatal Python error: Segmentation fault

Current thread 0x00000001056d3dc0 (most recent call first):
  File "/Users/vhaenel/git/numba-integration-testing/fastparquet/fastparquet/test/test_with_n.py", line 74 in test_hybrid_extra_bytes
  File "/Users/vhaenel/git/numba-integration-testing/miniconda3/envs/fastparquet/lib/python3.7/site-packages/_pytest/python.py", line 183 in pytest_pyfunc_call
  File "/Users/vhaenel/git/numba-integration-testing/miniconda3/envs/fastparquet/lib/python3.7/site-packages/pluggy/callers.py", line 187 in _multicall
  File "/Users/vhaenel/git/numba-integration-testing/miniconda3/envs/fastparquet/lib/python3.7/site-packages/pluggy/manager.py", line 87 in <lambda>
  File "/Users/vhaenel/git/numba-integration-testing/miniconda3/envs/fastparquet/lib/python3.7/site-packages/pluggy/manager.py", line 93 in _hookexec
  File "/Users/vhaenel/git/numba-integration-testing/miniconda3/envs/fastparquet/lib/python3.7/site-packages/pluggy/hooks.py", line 286 in __call__
  File "/Users/vhaenel/git/numba-integration-testing/miniconda3/envs/fastparquet/lib/python3.7/site-packages/_pytest/python.py", line 1641 in runtest
  File "/Users/vhaenel/git/numba-integration-testing/miniconda3/envs/fastparquet/lib/python3.7/site-packages/_pytest/runner.py", line 162 in pytest_runtest_call
  File "/Users/vhaenel/git/numba-integration-testing/miniconda3/envs/fastparquet/lib/python3.7/site-packages/pluggy/callers.py", line 187 in _multicall
  File "/Users/vhaenel/git/numba-integration-testing/miniconda3/envs/fastparquet/lib/python3.7/site-packages/pluggy/manager.py", line 87 in <lambda>
  File "/Users/vhaenel/git/numba-integration-testing/miniconda3/envs/fastparquet/lib/python3.7/site-packages/pluggy/manager.py", line 93 in _hookexec
  File "/Users/vhaenel/git/numba-integration-testing/miniconda3/envs/fastparquet/lib/python3.7/site-packages/pluggy/hooks.py", line 286 in __call__
  File "/Users/vhaenel/git/numba-integration-testing/miniconda3/envs/fastparquet/lib/python3.7/site-packages/_pytest/runner.py", line 255 in <lambda>
  File "/Users/vhaenel/git/numba-integration-testing/miniconda3/envs/fastparquet/lib/python3.7/site-packages/_pytest/runner.py", line 311 in from_call
  File "/Users/vhaenel/git/numba-integration-testing/miniconda3/envs/fastparquet/lib/python3.7/site-packages/_pytest/runner.py", line 255 in call_runtest_hook
  File "/Users/vhaenel/git/numba-integration-testing/miniconda3/envs/fastparquet/lib/python3.7/site-packages/_pytest/runner.py", line 215 in call_and_report
  File "/Users/vhaenel/git/numba-integration-testing/miniconda3/envs/fastparquet/lib/python3.7/site-packages/_pytest/runner.py", line 126 in runtestprotocol
  File "/Users/vhaenel/git/numba-integration-testing/miniconda3/envs/fastparquet/lib/python3.7/site-packages/_pytest/runner.py", line 109 in pytest_runtest_protocol
  File "/Users/vhaenel/git/numba-integration-testing/miniconda3/envs/fastparquet/lib/python3.7/site-packages/pluggy/callers.py", line 187 in _multicall
  File "/Users/vhaenel/git/numba-integration-testing/miniconda3/envs/fastparquet/lib/python3.7/site-packages/pluggy/manager.py", line 87 in <lambda>
  File "/Users/vhaenel/git/numba-integration-testing/miniconda3/envs/fastparquet/lib/python3.7/site-packages/pluggy/manager.py", line 93 in _hookexec
  File "/Users/vhaenel/git/numba-integration-testing/miniconda3/envs/fastparquet/lib/python3.7/site-packages/pluggy/hooks.py", line 286 in __call__
  File "/Users/vhaenel/git/numba-integration-testing/miniconda3/envs/fastparquet/lib/python3.7/site-packages/_pytest/main.py", line 348 in pytest_runtestloop
  File "/Users/vhaenel/git/numba-integration-testing/miniconda3/envs/fastparquet/lib/python3.7/site-packages/pluggy/callers.py", line 187 in _multicall
  File "/Users/vhaenel/git/numba-integration-testing/miniconda3/envs/fastparquet/lib/python3.7/site-packages/pluggy/manager.py", line 87 in <lambda>
  File "/Users/vhaenel/git/numba-integration-testing/miniconda3/envs/fastparquet/lib/python3.7/site-packages/pluggy/manager.py", line 93 in _hookexec
  File "/Users/vhaenel/git/numba-integration-testing/miniconda3/envs/fastparquet/lib/python3.7/site-packages/pluggy/hooks.py", line 286 in __call__
  File "/Users/vhaenel/git/numba-integration-testing/miniconda3/envs/fastparquet/lib/python3.7/site-packages/_pytest/main.py", line 323 in _main
  File "/Users/vhaenel/git/numba-integration-testing/miniconda3/envs/fastparquet/lib/python3.7/site-packages/_pytest/main.py", line 269 in wrap_session
  File "/Users/vhaenel/git/numba-integration-testing/miniconda3/envs/fastparquet/lib/python3.7/site-packages/_pytest/main.py", line 316 in pytest_cmdline_main
  File "/Users/vhaenel/git/numba-integration-testing/miniconda3/envs/fastparquet/lib/python3.7/site-packages/pluggy/callers.py", line 187 in _multicall
  File "/Users/vhaenel/git/numba-integration-testing/miniconda3/envs/fastparquet/lib/python3.7/site-packages/pluggy/manager.py", line 87 in <lambda>
  File "/Users/vhaenel/git/numba-integration-testing/miniconda3/envs/fastparquet/lib/python3.7/site-packages/pluggy/manager.py", line 93 in _hookexec
  File "/Users/vhaenel/git/numba-integration-testing/miniconda3/envs/fastparquet/lib/python3.7/site-packages/pluggy/hooks.py", line 286 in __call__
  File "/Users/vhaenel/git/numba-integration-testing/miniconda3/envs/fastparquet/lib/python3.7/site-packages/_pytest/config/__init__.py", line 163 in main
  File "/Users/vhaenel/git/numba-integration-testing/fastparquet/.eggs/pytest_runner-5.2-py3.7.egg/ptr.py", line 220 in run_tests
  File "/Users/vhaenel/git/numba-integration-testing/fastparquet/.eggs/pytest_runner-5.2-py3.7.egg/ptr.py", line 209 in run
  File "/Users/vhaenel/git/numba-integration-testing/miniconda3/envs/fastparquet/lib/python3.7/distutils/dist.py", line 985 in run_command
  File "/Users/vhaenel/git/numba-integration-testing/miniconda3/envs/fastparquet/lib/python3.7/distutils/dist.py", line 966 in run_commands
  File "/Users/vhaenel/git/numba-integration-testing/miniconda3/envs/fastparquet/lib/python3.7/distutils/core.py", line 148 in setup
  File "/Users/vhaenel/git/numba-integration-testing/miniconda3/envs/fastparquet/lib/python3.7/site-packages/setuptools/__init__.py", line 153 in setup
  File "setup.py", line 98 in <module>
/Users/vhaenel/git/numba-integration-testing/miniconda3/envs/fastparquet/.tmpk_4yfmx9: line 3: 94910 Segmentation fault: 11  (core dumped) python setup.py test
ERROR conda.cli.main_run:execute(33): Subprocess for 'conda run ['python', 'setup.py', 'test']' command failed.  (See above for error)
::>> running: 'conda list -n fastparquet'
# packages in environment at /Users/vhaenel/git/numba-integration-testing/miniconda3/envs/fastparquet:
#
# Name                    Version                   Build  Channel
fastparquet               0.5.0                    pypi_0    pypi
llvmlite                  0.36.0dev0              py37_31    numba/label/dev
numba                     0.53.0dev0      np1.11py3.7h6440ff4_g674f77b_423    numba/label/dev
::>> The following tests failed: '['fastparquet']'
python3 switchboard.py -t fastparquet  182.12s user 48.88s system 67% cpu 5:39.88 total