### PR TITLE
add poliastro

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -74,6 +74,12 @@ jobs:
       - run-target:
           target: "tardis"
 
+  poliastro:
+    executor: test-executor
+    steps:
+      - run-target:
+          target: "poliastro"
+
 
 workflows:
   version: 2.1
@@ -88,6 +94,7 @@ workflows:
       - datashader
       - pandas
       - tardis
+      - poliastro
   nightly-integration-testing:
     jobs:
       - umap
@@ -99,6 +106,7 @@ workflows:
       - datashader
       - pandas
       - tardis
+      - poliastro
     triggers:
       - schedule:
           cron: "0 5 * * *"

--- a/switchboard.py
+++ b/switchboard.py
@@ -353,5 +353,35 @@ class TardisTests(GitTarget):
         os.chdir('../')
 
 
+class PoliastroTests(GitTarget):
+
+    @property
+    def name(self):
+        return "poliastro"
+
+    @property
+    def clone_url(self):
+        return "https://github.com/poliastro/poliastro.git"
+
+    @property
+    def git_ref(self):
+        return git_latest_tag(self.clone_url)
+
+    @property
+    def conda_dependencies(self):
+        return ["-c conda-forge coverage hypothesis mypy>=0.740 "
+                "poliastro pip pytest>=3.2 pytest-cov<2.6.0 "
+                "pytest-doctestplus>=0.8 pytest-mpl pytest-mypy "
+                "pytest-remotedata"]
+
+    @property
+    def install_command(self):
+        return "conda remove --force poliastro && pip install -e ."
+
+    @property
+    def test_command(self):
+        return 'cd tests && pytest -m "not slow and not mpl_image_compare"'
+
+
 if __name__ == "__main__":
     main(NumbaSource())


### PR DESCRIPTION
This is a continuation of #25 @esc @astrojuanlu

I tried to avoid maintaining dependencies on another file (enough with `pyproject.toml` and `conda-forge` recipe) by:

- Installing `poliastro` from `conda-forge` (all runtime packages are pulled from `conda-forge`)
- Re-installing `poliastro` package from source + `dev` dependencies with `pip install -e .[dev]`

Results:  `938 passed, 59 skipped, 33 deselected, 5 xfailed, 1 warning in 136.64s (0:02:16)`
