### PR TITLE
Create individual status badges for packages 

### DIFF
--- a/.ci-helpers/badges.py
+++ b/.ci-helpers/badges.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python
+import os
+import requests
+
+from parse import parse
+
+GH_API_URL = os.getenv("GH_API_URL")
+GH_TOKEN = os.getenv("GH_TOKEN")
+JB_ENDPOINT = os.getenv("JB_ENDPOINT")
+JB_TOKEN = os.getenv("JB_TOKEN")
+
+r = requests.get(GH_API_URL, headers={"authorization": f"token {GH_TOKEN}"})
+print(f"Status Code: {r.status_code}, Response: {r.json()}")
+
+data = r.json()
+states = dict()
+for elem in data:
+    context = parse("ci/circleci: {package}", elem["context"])
+    state = elem["state"]
+
+    if state in ["success", "failure"]:
+        states[context.named["package"]] = state
+
+for pkg, state in states.items():
+    badge_dict = {"schemaVersion": 1,
+                  "label": pkg,
+                  "message": "passing" if state == "success" else "failing",
+                  "color": "brightgreen" if state == "success" else "red",
+                  "namedLogo": "numba",
+                  "logoColor": "white"}
+
+    r = requests.post(f"{JB_ENDPOINT}/{pkg}/badge", json=badge_dict, headers={"authorization": f"token {JB_TOKEN}"})
+    print(f"Status Code: {r.status_code}, Response: {r.json()}")
+
+    r = requests.put(f"{JB_ENDPOINT}/{pkg}/badge/_perms", headers={"authorization": f"token {JB_TOKEN}"})
+    print(f"Status Code: {r.status_code}, Response: {r.json()}")

--- a/.github/workflows/badges.yml
+++ b/.github/workflows/badges.yml
@@ -1,0 +1,36 @@
+# Log in to jsonbin.org with tardis-bot GitHub account to get an API key and 
+# store it as a repository secret.
+
+# Updated badges will be available at:
+# https://img.shields.io/endpoint?url=https://jsonbin.org/numba/numba-integration-testing/nightly/<package>/badge
+
+name: badges
+
+on:
+  schedule:
+    - cron: '0 6 * * *'
+
+  workflow_dispatch:  # trigger manually
+
+env:
+  GH_API_URL: https://api.github.com/repos/numba/numba-integration-testing/statuses/master
+  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  JB_ENDPOINT: https://jsonbin.org/numba/numba-integration-testing/nightly
+  JB_TOKEN: ${{ secrets.JSONBIN_APIKEY }}
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Setup Python
+        uses: actions/setup-python@v3
+        with:
+          python-version: '3.9'
+
+      - name: Install packages
+        run: pip install requests==2.27.1 parse==1.19.0
+
+      - name: Update badges
+        run: python .ci-helpers/badges.py


### PR DESCRIPTION
This pull request will enable the automatic creation (and update) of status badges specific to every job (packages).

Some considerations:
- Requires logging to JSONbin.org with the organization GitHub account
- This workflow is scheduled to run an hour after the nightly tests start
- The workflow can be run manually
- Why not a `push` trigger? Because immediately after pushing changes to master the jobs will be marked as "pending". This could be fixed by using the previous commit SHA to create badges after push, but I think it's not necessary for a first implementation of the workflow
- Badges are created through the [shields.io endpoint](https://shields.io/endpoint) by storing a JSON dictionary in JSONbin.org
- Badges will be available at `https://img.shields.io/endpoint?url=https://jsonbin.org/numba/numba-integration-testing/nightly/<package>/badge`
- After merging this PR, wait an hour and run the workflow manually. Otherwise, the status of the jobs are "pending" and will be ignored
- **IMPORTANT:** scheduled workflows will be disabled in public repos with no activity for 60 consecutive days. That's GitHub policy, nothing I can do.

Example: https://github.com/epassaro/numba-integration-badges

Closes #86 